### PR TITLE
Add compatibility for Python 3, add compatability for pyvisa import naming

### DIFF
--- a/pyivi/ivic/ivifgen.py
+++ b/pyivi/ivic/ivifgen.py
@@ -38,7 +38,7 @@ class ShortCutFreqGen(ShortCut):
         
     @property
     def channel_name(self):
-        return self.parent.channels.keys()[self.channel_idx-1]
+        return list(self.parent.channels.keys())[self.channel_idx-1]
 
 
 add_sc_fields(ShortCutFreqGen, 

--- a/pyivi/ivic/iviscope.py
+++ b/pyivi/ivic/iviscope.py
@@ -41,11 +41,11 @@ class ShortCutScope(ShortCut):
     def __init__(self, parent):
         super(ShortCutScope, self).__init__(parent)
         self.channel_idx = 1
-        self.channel_idxs = Enum(['select channel'] + parent.channels.keys())
+        self.channel_idxs = Enum(['select channel'] + list(parent.channels.keys()))
         
     @property
     def channel_name(self):
-        return self.parent.channels.keys()[self.channel_idx-1]
+        return list(self.parent.channels.keys())[self.channel_idx-1]
 
     def fetch(self):
         return self.parent.channels[self.channel_name].fetch_waveform()
@@ -79,7 +79,7 @@ class IviCScope(IviCWrapper):
         """
         
         if not channel:
-            channel = self.channels.keys()[0]
+            channel = list(self.channels.keys())[0]
         chan = ctypes.c_char_p(channel)
         py_len = self.horz_record_length
         length = ctypes.c_int(py_len)
@@ -109,7 +109,7 @@ class IviCScope(IviCWrapper):
         """
         
         if not channel:
-            channel = self.channels.keys()[0]
+            channel = list(self.channels.keys())[0]
         chan = ctypes.c_char_p(channel)
         py_len = self.horz_record_length
         length = ctypes.c_int(py_len)

--- a/pyivi/ivic/ivispecan.py
+++ b/pyivi/ivic/ivispecan.py
@@ -32,7 +32,7 @@ class ShortCutSpecAn(ShortCut):
     def __init__(self, parent):
         super(ShortCutSpecAn, self).__init__(parent)
         self.trace_idx = 1
-        self.trace_idxs = Enum(['select trace'] + parent.traces.keys())
+        self.trace_idxs = Enum(['select trace'] + list(parent.traces.keys()))
 
     @property
     def frequency_center(self):
@@ -58,7 +58,7 @@ class ShortCutSpecAn(ShortCut):
         
     @property
     def trace_name(self):
-        return self.parent.traces.keys()[self.trace_idx-1]
+        return list(self.parent.traces.keys())[self.trace_idx-1]
 
     @property
     def active_trace(self):
@@ -118,7 +118,7 @@ class IviCSpecAn(IviCWrapper):
         """
         
         if not trace_name:
-            trace_name = self.traces.keys()[0]
+            trace_name = list(self.traces.keys())[0]
         trace_name_c = ctypes.c_char_p(trace_name)
         trace = self.traces[trace_name]
         py_len = trace.trace_size
@@ -145,7 +145,7 @@ class IviCSpecAn(IviCWrapper):
         """
         
         if not trace_name:
-            trace_name = self.traces.keys()[0]
+            trace_name = list(self.traces.keys())[0]
         trace_name_c = ctypes.c_char_p(trace_name)
         trace = self.traces[trace_name]
         timeout_ms_c = ctypes.c_int32(timeout_ms)

--- a/pyivi/ivicom/agna.py
+++ b/pyivi/ivicom/agna.py
@@ -93,7 +93,7 @@ class ShortCutNA(ShortCut):
         
         self.measurement_idx = 1
         self.measurement_idxs = Enum(['select measurement'] + \
-                                     self.active_channel.measurements.keys())
+                                     list(self.active_channel.measurements.keys()))
         self.create_measurement()
     
     @property

--- a/pyivi/ivicom/agna.py
+++ b/pyivi/ivicom/agna.py
@@ -88,7 +88,7 @@ class ShortCutNA(ShortCut):
     def __init__(self, parent):
         super(ShortCutNA, self).__init__(parent)
         self.channel_idx = 1
-        self.channel_idxs = Enum(['select channel'] + parent.channels.keys())
+        self.channel_idxs = Enum(['select channel'] + list(parent.channels.keys()))
         self._measurement_idx = 1
         
         self.measurement_idx = 1
@@ -111,7 +111,7 @@ class ShortCutNA(ShortCut):
     
     @property
     def input_port(self):
-       return self.active_measurement.get_s_parameter()[0]
+       return list(self.active_measurement.get_s_parameter())[0] #casting as list may not be necessary
    
     @input_port.setter
     def input_port(self, val):
@@ -121,7 +121,7 @@ class ShortCutNA(ShortCut):
     
     @property
     def output_port(self):
-        return self.active_measurement.get_s_parameter()[1]
+        return list(self.active_measurement.get_s_parameter())[1] #casting as list may not be necessary
     
     @output_port.setter
     def output_port(self, val):
@@ -131,7 +131,7 @@ class ShortCutNA(ShortCut):
     
     @property
     def measurement_name(self):
-        return self.active_channel.measurements.keys()[self.measurement_idx-1]
+        return list(self.active_channel.measurements.keys())[self.measurement_idx-1]
     
     @property
     def active_measurement(self):
@@ -142,7 +142,7 @@ class ShortCutNA(ShortCut):
         
     @property
     def channel_name(self):
-        return self.parent.channels.keys()[self.channel_idx-1]
+        return list(self.parent.channels.keys())[self.channel_idx-1]
 
     @property
     def active_channel(self):

--- a/pyivi/ivicom/iviscope.py
+++ b/pyivi/ivicom/iviscope.py
@@ -151,10 +151,10 @@ class ShortCutScope(ShortCut):
     def __init__(self, parent):
         super(ShortCutScope, self).__init__(parent)
         self.channel_idx = 1
-        self.channel_idxs = Enum(['select channel'] + parent.channels.keys())
+        self.channel_idxs = Enum(['select channel'] + list(parent.channels.keys()))
     @property
     def channel_name(self):
-        return self.parent.channels.keys()[self.channel_idx-1]
+        return list(self.parent.channels.keys())[self.channel_idx-1]
     
     def fetch(self):
         return self.parent.measurements[self.channel_name].fetch_waveform()

--- a/pyivi/ivicom/ivispecan.py
+++ b/pyivi/ivicom/ivispecan.py
@@ -158,7 +158,7 @@ class ShortCutSpecAn(ShortCut):
     def __init__(self, parent):
         super(ShortCutSpecAn, self).__init__(parent)
         self.trace_idx = 1
-        self.trace_idxs = Enum(['select trace'] + parent.traces.keys())
+        self.trace_idxs = Enum(['select trace'] + list(parent.traces.keys()))
         
     @property
     def frequency_center(self):

--- a/pyivi/ivicom/ivispecan.py
+++ b/pyivi/ivicom/ivispecan.py
@@ -184,7 +184,7 @@ class ShortCutSpecAn(ShortCut):
     
     @property
     def trace_name(self):
-        return self.parent.traces.keys()[self.trace_idx-1]
+        return list(self.parent.traces.keys())[self.trace_idx-1]
 
     @property
     def active_trace(self):

--- a/pyivi/ivifactory/__init__.py
+++ b/pyivi/ivifactory/__init__.py
@@ -220,8 +220,8 @@ def supporting_modules(model):
 def get_model_name(address):
     """Physically queries the instrument model at the given address"""
     
-    from visa import VisaIOError
-    import visa
+    from pyvisa import VisaIOError
+    import pyvisa as visa
     model = "no device"
     try:
         instr = visa.Instrument(str(address))

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(fname):
 
 setup(
     name="pyivi",
-    version="0.0.8",
+    version="0.0.9",
     author = "Samuel Deleglise",
     author_email = "samuel.deleglise@gmail.com",
     description = ("""Control of data acquisition with remote instruments using 


### PR DESCRIPTION
In Python 3, Ordered Dictionary method 'keys()' is not indexable. Because of this, it won't concatenate with list objects, or allow indexing unless first cast to a list object. Tested on Python 3.8.6 (64-bit).

Updated import of pyvisa per deprecation warning:
"FutureWarning: The visa module provided by PyVISA 
is being deprecated. You can replace `import visa` by `import pyvisa as visa` to achieve the same effect.

The reason for the deprecation is the possible conflict with the visa package provided by the https://github.com/visa-sdk/visa-python which can result in hard to debug situations."